### PR TITLE
Update tag_contactFormConfirmationRecruitAndInclude.html

### DIFF
--- a/force-app/main/default/lwc/tag_contactFormConfirmationRecruitAndInclude/tag_contactFormConfirmationRecruitAndInclude.html
+++ b/force-app/main/default/lwc/tag_contactFormConfirmationRecruitAndInclude/tag_contactFormConfirmationRecruitAndInclude.html
@@ -51,9 +51,8 @@
         <br>
 
          <!--============================Text Area UX-Signals=========================================-->
-         <div >
-            <iframe data-uxsignals-embed="panel-zlwac6q9cp" style="width: 460px; border-width: 0px; Height:540px;" src="https://app.uxsignals.com/dialog/panel-zlwac6q9cp"></iframe> 
-        </div>
+         <!--There are currently no UX-signals. This is a placeholder for where to put future components-->
+         
 
         <!--============================Text Area Inquiry Flow=========================================-->
 


### PR DESCRIPTION
Fjernet div-tagger og iframe for ux-signals.
Innholdsteamet har bedt oss fjerne ux-signals siden de er ferdige med undersøkelsen. Ikke umulig at de skal ha andre undersøkelser i fremtiden så beholdt oppsettet med 2 landingssider osv. slik at vi det blir mindre jobb å legge til igjen. Beholdt også rutingslogikken og placeholder i html-koden som viser hvor det lå.
